### PR TITLE
Add test for hex address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Ignore Gradle project-specific cache directory
 .gradle
+.hmy_java
 
 # Ignore Gradle build output directory
 build

--- a/src/main/java/one/harmony/account/Address.java
+++ b/src/main/java/one/harmony/account/Address.java
@@ -26,8 +26,8 @@ public class Address {
 	private final String oneAddr;
 	private final String hexAddr;
 
-	public Address(String addr, boolean isHex) {
-		if (isHex) {
+	public Address(String addr) {
+		if (addr.startsWith("0x")) {
 			this.oneAddr = toBech32(addr);
 			this.hexAddr = addr;
 		} else {

--- a/src/main/java/one/harmony/account/HistoryParams.java
+++ b/src/main/java/one/harmony/account/HistoryParams.java
@@ -39,7 +39,8 @@ public class HistoryParams {
 	 * @param address
 	 */
 	public HistoryParams(String address) {
-		this.address = address;
+		Address addr = new Address(address);
+		this.address = addr.getOneAddr();
 	}
 
 	public String getAddress() {
@@ -47,7 +48,8 @@ public class HistoryParams {
 	}
 
 	public void setAddress(String address) {
-		this.address = address;
+		Address addr = new Address(address);
+		this.address = addr.getOneAddr();
 	}
 
 	public int getPageIndex() {

--- a/src/main/java/one/harmony/cmd/Contract.java
+++ b/src/main/java/one/harmony/cmd/Contract.java
@@ -64,19 +64,34 @@ public abstract class Contract {
 	protected Contract(String contractBinary, String contractAddress, Handler handler,
 			ContractGasProvider gasProvider) {
 		this.handler = handler;
-		this.contractAddress = contractAddress;
+		if (contractAddress == null) {
+			this.contractAddress = null;
+		} else {
+			one.harmony.account.Address addr = new one.harmony.account.Address(contractAddress);
+			this.contractAddress = addr.getHexAddr();
+		}
 		this.contractBinary = contractBinary;
 		this.gasProvider = gasProvider;
 	}
 
 	protected Contract(String contractBinary, String contractAddress, ContractGasProvider gasProvider) {
-		this.contractAddress = contractAddress;
+		if (contractAddress == null) {
+			this.contractAddress = null;
+		} else {
+			one.harmony.account.Address addr = new one.harmony.account.Address(contractAddress);
+			this.contractAddress = addr.getHexAddr();
+		}
 		this.contractBinary = contractBinary;
 		this.gasProvider = gasProvider;
 	}
 
 	protected Contract(String contractBinary, String contractAddress, BigInteger gasPrice, BigInteger gasLimit) {
-		this.contractAddress = contractAddress;
+		if (contractAddress == null) {
+			this.contractAddress = null;
+		} else {
+			one.harmony.account.Address addr = new one.harmony.account.Address(contractAddress);
+			this.contractAddress = addr.getHexAddr();
+		}
 		this.contractBinary = contractBinary;
 		this.gasProvider = new StaticGasProvider(gasPrice, gasLimit);
 	}
@@ -86,7 +101,12 @@ public abstract class Contract {
 	}
 
 	public void setContractAddress(String contractAddress) {
-		this.contractAddress = contractAddress;
+		if (contractAddress == null) {
+			this.contractAddress = null;
+		} else {
+			one.harmony.account.Address addr = new one.harmony.account.Address(contractAddress);
+			this.contractAddress = addr.getHexAddr();
+		}
 	}
 
 	public String getContractAddress() {

--- a/src/main/java/one/harmony/cmd/Transfer.java
+++ b/src/main/java/one/harmony/cmd/Transfer.java
@@ -223,8 +223,7 @@ public class Transfer {
 		}
 
 		String accountName = Store.getAccountNameFromAddress(this.from);
-		boolean isHex = false;
-		Address address = new Address(this.from, isHex);
+		Address address = new Address(this.from);
 		WalletFile walletFile = Store.extractWalletFileFromAddress(this.from);
 		Credentials credentials = Credentials.create(Wallet.decrypt(passphrase, walletFile));
 		Account account = new Account(accountName, address, credentials, walletFile);

--- a/src/main/java/one/harmony/keys/Store.java
+++ b/src/main/java/one/harmony/keys/Store.java
@@ -69,14 +69,15 @@ public class Store {
 		throw new FileNotFoundException();
 	}
 
-	public static File getKeyFileFromAddress(String oneAddress) throws FileNotFoundException {
+	public static File getKeyFileFromAddress(String address) throws FileNotFoundException {
+		Address addr = new Address(address);
 		String keysDirName = getDefaultKeyDirectory();
 		File keysDir = new File(keysDirName);
 
 		for (File file : keysDir.listFiles()) {
 			if (file.isDirectory()) {
 				File keyFile = file.listFiles()[0];
-				if (keyFile.getName().equals(oneAddress + ".json")) {
+				if (keyFile.getName().equals(addr.getOneAddr() + ".json")) {
 					return keyFile;
 				}
 			}
@@ -84,19 +85,20 @@ public class Store {
 		throw new FileNotFoundException();
 	}
 
-	public static String getAccountNameFromAddress(String oneAddress) throws IllegalArgumentException {
+	public static String getAccountNameFromAddress(String address) throws IllegalArgumentException {
+		Address addr = new Address(address);
 		String keysDirName = getDefaultKeyDirectory();
 		File keysDir = new File(keysDirName);
 
 		for (File file : keysDir.listFiles()) {
 			if (file.isDirectory()) {
 				File keyFile = file.listFiles()[0];
-				if (keyFile.getName().equals(oneAddress + ".json")) {
+				if (keyFile.getName().equals(addr.getOneAddr() + ".json")) {
 					return file.getName();
 				}
 			}
 		}
-		throw new IllegalArgumentException("Account does not exists for address: " + oneAddress);
+		throw new IllegalArgumentException("Account does not exists for address: " + addr.getOneAddr());
 	}
 
 	public static Map<String, String> getLocalAccounts() {
@@ -118,12 +120,14 @@ public class Store {
 		return getLocalAccounts().containsKey(name);
 	}
 
-	public static boolean doesAccountExists(String oneAddress) {
-		return getLocalAccounts().values().contains(oneAddress);
+	public static boolean doesAccountExists(String address) {
+		Address addr = new Address(address);
+		return getLocalAccounts().values().contains(addr.getHexAddr());
 	}
 
-	public static String searchForAccount(String oneAddress) throws IllegalArgumentException {
-		return getAccountNameFromAddress(oneAddress);
+	public static String searchForAccount(String address) throws IllegalArgumentException {
+		Address addr = new Address(address);
+		return getAccountNameFromAddress(addr.getHexAddr());
 	}
 
 	public static String getDefaultKeyDirectory() {
@@ -137,12 +141,13 @@ public class Store {
 		return accountDir;
 	}
 
-	public static boolean setAccountName(String oneAddress, String accountName) {
+	public static boolean setAccountName(String address, String accountName) {
+		Address addr = new Address(address);
 		File keysDir = new File(getDefaultKeyDirectory());
 		for (File dir : keysDir.listFiles()) {
 			if (dir.isDirectory()) {
 				File addressFile = dir.listFiles()[0];
-				if (addressFile.getName().equals(oneAddress)) {
+				if (addressFile.getName().equals(addr.getOneAddr())) {
 					File newDir = new File(String.format("%s%s%s", dir.getParent(), File.separator, accountName));
 					dir.renameTo(newDir);
 				}
@@ -191,9 +196,10 @@ public class Store {
 		return objectMapper.readValue(keyFile, WalletFile.class);
 	}
 
-	public static WalletFile extractWalletFileFromAddress(String oneAddress)
+	public static WalletFile extractWalletFileFromAddress(String address)
 			throws JsonParseException, JsonMappingException, IOException {
-		File keyFile = getKeyFileFromAddress(oneAddress);
+		Address addr = new Address(address);
+		File keyFile = getKeyFileFromAddress(addr.getOneAddr());
 		return objectMapper.readValue(keyFile, WalletFile.class);
 	}
 
@@ -216,8 +222,9 @@ public class Store {
 		return usingBufferedReader(keyFile);
 	}
 
-	public static String extractKeyStoreFileFromAddress(String oneAddress) throws FileNotFoundException {
-		File keyFile = getKeyFileFromAddress(oneAddress);
+	public static String extractKeyStoreFileFromAddress(String address) throws FileNotFoundException {
+		Address addr = new Address(address);
+		File keyFile = getKeyFileFromAddress(addr.getOneAddr());
 		return usingBufferedReader(keyFile);
 	}
 

--- a/src/main/java/one/harmony/transaction/Handler.java
+++ b/src/main/java/one/harmony/transaction/Handler.java
@@ -68,8 +68,7 @@ public class Handler {
 		}
 		this.rpc = new RPC(this.url);
 		String accountName = Store.getAccountNameFromAddress(from);
-		boolean isHex = false;
-		Address address = new Address(from, isHex);
+		Address address = new Address(from);
 		WalletFile walletFile = Store.extractWalletFileFromAddress(from);
 		Credentials credentials = Credentials.create(Wallet.decrypt(passphrase, walletFile));
 		Account account = new Account(accountName, address, credentials, walletFile);
@@ -264,7 +263,7 @@ public class Handler {
 		if (this.sender != null) {
 			return this.sender.getAddress().getHexAddr();
 		} else if (this.from != null) {
-			return new Address(this.from, false).getHexAddr();
+			return new Address(this.from).getHexAddr();
 		} else {
 			return DEFAULT_FROM;
 		}

--- a/src/test/java/one/harmony/cmd/BalanceResponseTest.java
+++ b/src/test/java/one/harmony/cmd/BalanceResponseTest.java
@@ -2,8 +2,11 @@ package one.harmony.cmd;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.beans.Transient;
+
 import org.junit.jupiter.api.Test;
 
+import one.harmony.account.Address;
 import one.harmony.common.ResponseTester;
 import one.harmony.rpc.HmyResponse;
 
@@ -15,5 +18,12 @@ public class BalanceResponseTest extends ResponseTester {
 		buildResponse(expected);
 		HmyResponse response = deserialiseResponse(HmyResponse.class);
 		assertEquals(response.getResult(), ("0x230e5821e9bfaf1f285"));
+	}
+
+	@Test
+	public void testBalanceShard0() throws Exception {
+		String oneAddress = "one1pdv9lrdwl0rg5vglh4xtyrv3wjk3wsqket7zxy";
+		Address addr = new Address(oneAddress);
+		assertEquals(Balance.checkLocal(oneAddress), Balance.checkLocal(addr.getHexAddr()));
 	}
 }

--- a/src/test/java/one/harmony/cmd/CounterContractExample.java
+++ b/src/test/java/one/harmony/cmd/CounterContractExample.java
@@ -5,6 +5,7 @@ import java.math.BigInteger;
 import org.web3j.protocol.core.methods.response.TransactionReceipt;
 import org.web3j.tx.gas.ContractGasProvider;
 import org.web3j.tx.gas.StaticGasProvider;
+import org.junit.jupiter.api.Test;
 
 import one.harmony.transaction.ChainID;
 import one.harmony.transaction.Handler;

--- a/src/test/java/one/harmony/cmd/TransferTest.java
+++ b/src/test/java/one/harmony/cmd/TransferTest.java
@@ -1,6 +1,9 @@
 package one.harmony.cmd;
 
 import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import one.harmony.account.Address;
 
 public class TransferTest {
 	private static final int LOCAL_NET = 2;
@@ -17,21 +20,64 @@ public class TransferTest {
 		testImportPrivateKey();
 
 		String from = "one1pdv9lrdwl0rg5vglh4xtyrv3wjk3wsqket7zxy"; // Harmony localnet addresses
-		String to = "one1pf75h0t4am90z8uv3y0dgunfqp4lj8wr3t5rsp"; // Harmony localnet addresses
-		String amount = "1";
+		String to = "one18n8e7472pg5fqvcfcr5hg0npquha24wsxmjheg"; // Harmony localnet addresses
+		double amount = 1;
 		int fromShard = 0;
-		int toShard = 1;
+		int toShard = fromShard;
 		String memo = " ";// "0x5061796d656e7420666f722078797a";
 		// Create transfer object
-		Transfer t = new Transfer(from, to, amount, fromShard, toShard, memo);
+		Transfer t = new Transfer(from, to, String.valueOf(amount), fromShard, toShard, memo);
+
+		double fromBalance0 = Double.valueOf(Balance.checkLocal(from));
+		double toBalance0 = Double.valueOf(Balance.checkLocal(to));
+
 		// Prepare transfer
 		String passphrase = "harmony-one";
 		t.prepare(passphrase); // offline, no need to connect to network
 		// Execute transfer
 		boolean dryRun = false;
-		int waitToConfirmTime = 0;
+		int waitToConfirmTime = 2000;
 		String txHash = t.execute(LOCAL_NET, dryRun, waitToConfirmTime); // needs connection to network
 		Keys.cleanKeyStore();
+
+		assertTrue(Double.valueOf(Balance.checkLocal(from)) < fromBalance0 - amount);
+		assertTrue(Double.valueOf(Balance.checkLocal(to)) == toBalance0 + amount);
+	}
+
+	@Test
+	public void testTransferHexAddress() throws Exception {
+		Keys.cleanKeyStore();
+		testImportPrivateKey();
+
+		Address fromAddr = new Address("one1pdv9lrdwl0rg5vglh4xtyrv3wjk3wsqket7zxy");
+		Address toAddr = new Address("one18n8e7472pg5fqvcfcr5hg0npquha24wsxmjheg");
+		String from = fromAddr.getHexAddr();
+		String to = toAddr.getHexAddr();
+
+		double amount = 1;
+		int fromShard = 0;
+		int toShard = fromShard;
+		String memo = " ";// "0x5061796d656e7420666f722078797a";
+		// Create transfer object
+		Transfer t = new Transfer(from, to, String.valueOf(amount), fromShard, toShard, memo);
+
+		double fromBalance0 = Double.valueOf(Balance.checkLocal(from));
+		double toBalance0 = Double.valueOf(Balance.checkLocal(to));
+
+		// Prepare transfer
+		String passphrase = "harmony-one";
+		t.prepare(passphrase); // offline, no need to connect to network
+		// Execute transfer
+		boolean dryRun = false;
+		int waitToConfirmTime = 2000;
+		String txHash = t.execute(LOCAL_NET, dryRun, waitToConfirmTime); // needs connection to network
+		Keys.cleanKeyStore();
+
+		double fromBalance1 = Double.valueOf(Balance.checkLocal(from));
+		double toBalance1 = Double.valueOf(Balance.checkLocal(to));
+
+		assertTrue(fromBalance1 < fromBalance0 - amount);
+		assertTrue(toBalance1 == toBalance0 + amount);
 	}
 
 	@Test


### PR DESCRIPTION
Almost nothing to change to support hex address.
Added test script to verify its behavior with hex address in Transfer, and verified the test cases passing.

- Balance with hex address
  - Unit test has been added

- Blockchain with hex address
  - Supported by (https://github.com/polymorpher/harmonyj/commit/569a798695079668ac5f27a93ed661481234a9ba) as [Blockchain class accepts HistoryParams arg](https://github.com/polymorpher/harmonyj/blob/master/src/main/java/one/harmony/cmd/Blockchain.java#L65-L75).

- Contract with hex address
  - It accepted only hex address but one address, and I added one address support
  - Unit test for hex address support has been added